### PR TITLE
Fix pragma spelling

### DIFF
--- a/Example/HWSyscalls-Example/HWSyscalls.h
+++ b/Example/HWSyscalls-Example/HWSyscalls.h
@@ -24,7 +24,7 @@
 
 #pragma endregion
 
-#pragma region Type Defintions
+#pragma region Type Definitions
 
 typedef struct _UNICODE_STRING {
     USHORT Length;

--- a/Src/HWSyscalls.h
+++ b/Src/HWSyscalls.h
@@ -24,7 +24,7 @@
 
 #pragma endregion
 
-#pragma region Type Defintions
+#pragma region Type Definitions
 
 typedef struct _UNICODE_STRING {
     USHORT Length;


### PR DESCRIPTION
## Summary
- fix a typo in pragma region in library header and example header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882969558c08331956f1ae31c7d7782